### PR TITLE
607

### DIFF
--- a/app/models/NotificationEventSignal.java
+++ b/app/models/NotificationEventSignal.java
@@ -1,14 +1,12 @@
 package models;
 
 import com.avaje.ebean.annotation.DbJsonB;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import enums.SpaceTypes;
 import enums.SubscriptionTypes;
 import io.swagger.annotations.ApiModel;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import javax.persistence.*;
 
@@ -55,6 +53,9 @@ public class NotificationEventSignal extends AppCivistBaseModel {
 	@Column(name = "data")
 	@JsonInclude(Include.NON_EMPTY)
 	private Map<String, Object> data;
+
+	@OneToMany(cascade=CascadeType.ALL, mappedBy="signal", fetch=FetchType.LAZY)
+	private List<NotificationEventSignalUser> notificationsEventsSignalsUsers = new ArrayList<>();
 
 	// Information about the space where the event happened
 	/*private UUID origin;
@@ -137,6 +138,17 @@ public class NotificationEventSignal extends AppCivistBaseModel {
 
 	public NotificationEventSignal() {
 		super();
+	}
+	public List<NotificationEventSignalUser> getNotificationsEventsSignalsUsers() {
+		return notificationsEventsSignalsUsers;
+	}
+
+	public void setNotificationsEventsSignalsUsers(List<NotificationEventSignalUser> notificationsEventsSignalsUsers) {
+		this.notificationsEventsSignalsUsers = notificationsEventsSignalsUsers;
+	}
+
+	public void addNotificationEventSignalUser(NotificationEventSignalUser signal){
+		this.notificationsEventsSignalsUsers.add(signal);
 	}
 
 

--- a/app/models/NotificationEventSignalUser.java
+++ b/app/models/NotificationEventSignalUser.java
@@ -1,0 +1,69 @@
+package models;
+
+import com.avaje.ebean.annotation.Where;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonView;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import models.misc.Views;
+import sun.tools.tree.BooleanExpression;
+
+import javax.persistence.*;
+
+/**
+ *
+ * Created by ggaona on 02/9/17.
+ *
+ */
+
+@Entity
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class NotificationEventSignalUser extends AppCivistBaseModel{
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne()
+    @Column(name = "user_id")
+    private User user;
+
+    private Boolean read = false;
+
+    @ManyToOne()
+    @Column(name = "notification_event_signal_id")
+    private NotificationEventSignal signal;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public NotificationEventSignal getSignal() {
+        return signal;
+    }
+
+    public void setSignal(NotificationEventSignal signal) {
+        this.signal = signal;
+    }
+
+    public Boolean getRead() {
+        return read;
+    }
+
+    public void setRead(Boolean read) {
+        this.read = read;
+    }
+
+}

--- a/app/models/NotificationEventSignalUser.java
+++ b/app/models/NotificationEventSignalUser.java
@@ -1,24 +1,16 @@
 package models;
 
-import com.avaje.ebean.annotation.Where;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonView;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
-import models.misc.Views;
-import sun.tools.tree.BooleanExpression;
 
 import javax.persistence.*;
 
 /**
- *
  * Created by ggaona on 02/9/17.
- *
  */
 
 @Entity
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class NotificationEventSignalUser extends AppCivistBaseModel{
+public class NotificationEventSignalUser extends AppCivistBaseModel {
 
     @Id
     @GeneratedValue
@@ -33,6 +25,12 @@ public class NotificationEventSignalUser extends AppCivistBaseModel{
     @ManyToOne()
     @Column(name = "notification_event_signal_id")
     private NotificationEventSignal signal;
+
+    public NotificationEventSignalUser(User user, NotificationEventSignal notificationEvent) {
+        this.user = user;
+        this.signal = notificationEvent;
+        this.read = false;
+    }
 
     public Long getId() {
         return id;

--- a/app/models/Subscription.java
+++ b/app/models/Subscription.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 import enums.SpaceTypes;
 import enums.SubscriptionTypes;
+import models.transfer.NotificationSignalTransfer;
 
 
 @Entity
@@ -165,14 +166,18 @@ public class Subscription extends Model {
         return membs;
     }
 
-    public static List<Subscription> findBySignal(NotificationEventSignal signal) {
+    public static List<Subscription> findBySignal(NotificationSignalTransfer signal) {
         /*
             * subscription.spaceType === signal.spaceType
     * subscription.spaceId === signal.spaceId
     * subscription.subscriptionType === signal.signalType
     * subscription.ignoredEventsList[signal.eventName] === null OR false
          */
-        com.avaje.ebean.Query<Subscription> q = find.where().eq("user.spaceType",signal.get).query();
+        com.avaje.ebean.Query<Subscription> q = find.where()
+                .eq("spaceType",signal.getSpaceType())
+                .eq("spaceId", signal.getSpaceId())
+                .eq("subscriptionType",signal.getSignalType())
+                .query();
         List<Subscription> membs = q.findList();
         return membs;
     }

--- a/app/models/Subscription.java
+++ b/app/models/Subscription.java
@@ -164,4 +164,16 @@ public class Subscription extends Model {
         List<Subscription> membs = q.findList();
         return membs;
     }
+
+    public static List<Subscription> findBySignal(NotificationEventSignal signal) {
+        /*
+            * subscription.spaceType === signal.spaceType
+    * subscription.spaceId === signal.spaceId
+    * subscription.subscriptionType === signal.signalType
+    * subscription.ignoredEventsList[signal.eventName] === null OR false
+         */
+        com.avaje.ebean.Query<Subscription> q = find.where().eq("user.spaceType",signal.get).query();
+        List<Subscription> membs = q.findList();
+        return membs;
+    }
 }

--- a/conf/evolutions/default/52.sql
+++ b/conf/evolutions/default/52.sql
@@ -1,0 +1,23 @@
+
+CREATE SEQUENCE public.notification_event_signal_user_id_seq
+  INCREMENT 1
+  MINVALUE 1
+  MAXVALUE 9223372036854775807
+  START 1
+  CACHE 1;
+
+CREATE TABLE public.notification_event_signal_user
+(
+  id bigint NOT NULL DEFAULT nextval('notification_event_signal_user_id_seq'::regclass),
+  user_user_id bigint,
+  notification_event_signal_id bigint,
+  read boolean,
+
+  CONSTRAINT pk_notification_event_signal_user PRIMARY KEY (id),
+  CONSTRAINT fk_user FOREIGN KEY (user_user_id) REFERENCES public.appcivist_user (user_id) MATCH SIMPLE,
+  CONSTRAINT fk_notification_event_signal FOREIGN KEY (notification_event_signal_id) REFERENCES public.notification_event_signal (id) MATCH SIMPLE
+      ON UPDATE NO ACTION ON DELETE NO ACTION
+)
+WITH (
+  OIDS=FALSE
+);

--- a/conf/evolutions/default/52.sql
+++ b/conf/evolutions/default/52.sql
@@ -6,9 +6,16 @@ CREATE SEQUENCE public.notification_event_signal_user_id_seq
   START 1
   CACHE 1;
 
+-- DROP TABLE public.notification_event_signal_user;
+
 CREATE TABLE public.notification_event_signal_user
 (
   id bigint NOT NULL DEFAULT nextval('notification_event_signal_user_id_seq'::regclass),
+  creation timestamp without time zone,
+  last_update timestamp without time zone,
+  lang character varying(255),
+  removal timestamp without time zone,
+  removed boolean,
   user_user_id bigint,
   notification_event_signal_id bigint,
   read boolean,

--- a/conf/sql/database-create-postgres.sql
+++ b/conf/sql/database-create-postgres.sql
@@ -1923,17 +1923,23 @@ CREATE SEQUENCE public.notification_event_signal_user_id_seq
   START 1
   CACHE 1;
 
+-- DROP TABLE public.notification_event_signal_user;
 
 CREATE TABLE public.notification_event_signal_user
 (
   id bigint NOT NULL DEFAULT nextval('notification_event_signal_user_id_seq'::regclass),
+  creation timestamp without time zone,
+  last_update timestamp without time zone,
+  lang character varying(255),
+  removal timestamp without time zone,
+  removed boolean,
   user_user_id bigint,
-  notification_event_signal_id bigint,
+  signal_id bigint,
   read boolean,
 
   CONSTRAINT pk_notification_event_signal_user PRIMARY KEY (id),
   CONSTRAINT fk_user FOREIGN KEY (user_user_id) REFERENCES public.appcivist_user (user_id) MATCH SIMPLE,
-  CONSTRAINT fk_notification_event_signal FOREIGN KEY (notification_event_signal_id) REFERENCES public.notification_event_signal (id) MATCH SIMPLE
+  CONSTRAINT fk_notification_event_signal FOREIGN KEY (signal_id) REFERENCES public.notification_event_signal (id) MATCH SIMPLE
       ON UPDATE NO ACTION ON DELETE NO ACTION
 )
 WITH (

--- a/conf/sql/database-create-postgres.sql
+++ b/conf/sql/database-create-postgres.sql
@@ -1864,6 +1864,7 @@ CREATE UNIQUE INDEX unique_subscription_of_user_in_space ON subscription (user_u
 ALTER TABLE public.config DROP CONSTRAINT ck_config_config_target;
 ALTER TABLE public.config ADD CONSTRAINT ck_config_config_target CHECK (config_target::text = ANY (ARRAY['ASSEMBLY'::character varying::text, 'CAMPAIGN'::character varying::text, 'COMPONENT'::character varying::text, 'WORKING_GROUP'::character varying::text, 'MODULE'::character varying::text, 'PROPOSAL'::character varying::text, 'CONTRIBUTION'::character varying::text,'USER'::character varying::text]))
 
+
 -- 51. SQL
 alter table subscription drop column user_user_id;
 alter table subscription add column user_id character varying(40);
@@ -1912,3 +1913,29 @@ CREATE INDEX ix_notification_event_id
   (id);
 
 -- Index: public.ix_notification_event_uuid
+
+-- 52. SQL
+
+CREATE SEQUENCE public.notification_event_signal_user_id_seq
+  INCREMENT 1
+  MINVALUE 1
+  MAXVALUE 9223372036854775807
+  START 1
+  CACHE 1;
+
+
+CREATE TABLE public.notification_event_signal_user
+(
+  id bigint NOT NULL DEFAULT nextval('notification_event_signal_user_id_seq'::regclass),
+  user_user_id bigint,
+  notification_event_signal_id bigint,
+  read boolean,
+
+  CONSTRAINT pk_notification_event_signal_user PRIMARY KEY (id),
+  CONSTRAINT fk_user FOREIGN KEY (user_user_id) REFERENCES public.appcivist_user (user_id) MATCH SIMPLE,
+  CONSTRAINT fk_notification_event_signal FOREIGN KEY (notification_event_signal_id) REFERENCES public.notification_event_signal (id) MATCH SIMPLE
+      ON UPDATE NO ACTION ON DELETE NO ACTION
+)
+WITH (
+  OIDS=FALSE
+);


### PR DESCRIPTION
Added NotificationEventSignalUser that contains the boolean attribute read, initialized to FALSE and relation between User and NotificationEventSignal model. 
Save NotificationEventSignalUser whenever a NotificationEventSignal is created according to subscriptions saved: 
1. Read all subscriptions filtering by:
subscription.spaceType === signal.spaceType
subscription.spaceId === signal.spaceId
subscription.subscriptionType === signal.signalType
subscription.ignoredEventsList[signal.eventName] === null OR false
2. For each subscription, get the identities of the userId. 
3. Create a NotificationEventSignalUser per user